### PR TITLE
Rename option names and allow custom selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,10 +113,10 @@ module.exports = {
 
 Type: `string`. Default: `is-dark`.
 
-`css`'s valid selector, which will switch dark theme.
+Any `CSS`'s valid selector, which will switch dark theme.
 
 ### `lightSelector`
 
 Type: `string`. Default: `is-light`.
 
-`css`'s valid selector, which will switch light theme.
+Any `CSS`'s valid selector, which will switch light theme.

--- a/README.md
+++ b/README.md
@@ -112,12 +112,12 @@ module.exports = {
 
 Type: `string`. Default: `is-dark`.
 
-CSS’s valid selector for `<html>` (alias for `:root`), which will switch dark theme.
+Any CSS’s valid selector for `<html>` (alias for `:root`), which will switch dark theme.
 Use `darkSelector: '[data-theme="dark"]'` if you will switch theme by setting `<html data-theme=dark>`
 
 ### `lightSelector`
 
 Type: `string`. Default: `is-light`.
 
-Any `CSS`'s valid selector, which will switch light theme.
+Any CSS's valid selector, which will switch light theme.
 Use `lightSelector: '[data-theme="light"]'` if you will switch theme by setting `<html data-theme="light">`

--- a/README.md
+++ b/README.md
@@ -102,22 +102,21 @@ themeSwitcher.addEventListener('change', () => {
 module.exports = {
   plugins: [
     require('postcss-dark-theme-class')({
-      darkClass: 'dark-theme',
-      lightClass: 'light-theme'
+      darkSelector: '.dark-theme',
+      lightSelector: '.light-theme'
     })
   ]
 }
 ```
 
-### `darkClass`
+### `darkSelector`
 
 Type: `string`. Default: `is-dark`.
 
-`html`’s class, which will switch dark theme.
+`css`'s valid selector, which will switch dark theme.
 
-
-### `lightClass`
+### `lightSelector`
 
 Type: `string`. Default: `is-light`.
 
-`html`’s class, which will switch light theme.
+`css`'s valid selector, which will switch light theme.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,6 @@ themeSwitcher.addEventListener('change', () => {
 
 [official docs]: https://github.com/postcss/postcss#usage
 
-
 ## Options
 
 ```js
@@ -113,10 +112,12 @@ module.exports = {
 
 Type: `string`. Default: `is-dark`.
 
-Any `CSS`'s valid selector, which will switch dark theme.
+CSS’s valid selector for `<html>` (alias for `:root`), which will switch dark theme.
+Use `darkSelector: '[data-theme="dark"]'` if you will switch theme by setting `<html data-theme=dark>`
 
 ### `lightSelector`
 
 Type: `string`. Default: `is-light`.
 
 Any `CSS`'s valid selector, which will switch light theme.
+Use `lightSelector: '[data-theme="light"]'` if you will switch theme by setting `<html data-theme="light">`

--- a/index.js
+++ b/index.js
@@ -3,21 +3,27 @@ let postcss = require('postcss')
 const PREFERS_COLOR_ONLY = /^\(\s*prefers-color-scheme\s*:\s*dark\s*\)$/
 const PREFERS_COLOR = /\(\s*prefers-color-scheme\s*:\s*dark\s*\)/g
 
-function checkClass (cls) {
-  if (typeof cls !== 'undefined' && cls.startsWith('.')) {
-    let fixed = cls.replace(/^./, '')
+function checkOptionName (opts, value) {
+  let optName = Object.keys(opts).find(key => opts[key] === value)
+
+  if (typeof value !== 'undefined' && optName === 'darkClass') {
     throw new Error(
-      `Replace "${ cls }" to "${ fixed }" in postcss-dark-theme-class option`
+      `Update ${ optName }: '${ value }' to darkSelector: '.${ value }'`
+    )
+  }
+  if (typeof value !== 'undefined' && optName === 'lightClass') {
+    throw new Error(
+      `Update ${ optName }: '${ value }' to lightSelector: '.${ value }'`
     )
   }
 }
 
 module.exports = postcss.plugin('postcss-dark-theme-class', (opts = { }) => {
-  checkClass(opts.darkClass)
-  checkClass(opts.lightClass)
+  checkOptionName(opts, opts.darkClass)
+  checkOptionName(opts, opts.lightClass)
 
-  let dark = '.' + (opts.darkClass || 'is-dark')
-  let light = ':not(.' + (opts.lightClass || 'is-light') + ')'
+  let dark = opts.darkSelector || '.is-dark'
+  let light = `:not(${ opts.lightSelector || '.is-light' })`
 
   function processSelectors (selectors, add) {
     return selectors.map(i => {

--- a/index.test.js
+++ b/index.test.js
@@ -95,14 +95,14 @@ it('allows to change class', () => run(
     html:not(.light-theme) a { color: white }
   }
     html.dark-theme a { color: white }`,
-  { darkClass: 'dark-theme', lightClass: 'light-theme' }
+  { darkSelector: '.dark-theme', lightSelector: '.light-theme' }
 ))
 
-it('throws on dot in class options', () => {
+it('throws on old options', () => {
   expect(() => {
-    run('', '', { darkClass: '.dark', lightClass: 'light' })
-  }).toThrow(/"dark"/)
+    run('', '', { darkClass: 'dark', lightSelector: '.light' })
+  }).toThrow("Update darkClass: 'dark' to darkSelector: '.dark'")
   expect(() => {
-    run('', '', { darkClass: 'dark', lightClass: '.light' })
-  }).toThrow(/"light"/)
+    run('', '', { darkSelector: '.dark', lightClass: 'light' })
+  }).toThrow("Update lightClass: 'light' to lightSelector: '.light'")
 })


### PR DESCRIPTION
This PR try to close #3 by renaming option names and allowing developers to set a custom `css` selector instead of a custom class name.

As is said I'm not a js developer so this could looks bad.