### PR TITLE
fix: handle comments

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,6 +46,8 @@ module.exports = (opts = {}) => {
                 selectors: processSelectors(node.selectors, dark)
               })
               node.selectors = processSelectors(node.selectors, light)
+            } else if (node.type === 'comment') {
+              fixed = node.clone()
             }
             last.after(fixed)
             last = fixed

--- a/index.test.js
+++ b/index.test.js
@@ -73,6 +73,24 @@ it('ignores whitespaces', () => {
   )
 })
 
+it('reserve comments', () => {
+  run(
+    `@media (prefers-color-scheme:dark) {
+    /* some comments */
+    a { color: white }
+    @media (min-width: 500px) { /* another comments */ a { } }
+  }`,
+    `@media (prefers-color-scheme:dark) {
+    /* some comments */
+    html:not(.is-light) a { color: white }
+    @media (min-width: 500px) { /* another comments */ html:not(.is-light) a { } }
+  }
+    /* some comments */
+    html.is-dark a { color: white }
+    @media (min-width: 500px) { /* another comments */ html.is-dark a { } }`
+  )
+})
+
 it('supports combined queries', () => {
   run(
     `@media (min-width: 60px) and (prefers-color-scheme: dark) {


### PR DESCRIPTION
This PR is to fix errors when comments exist in media queries.

For example, if you have a CSS like this,
```css
@media (prefers-color-scheme: dark) {
   /* comments about the style */
  a {
    color: white;
  }
}
```
it will raise error `TypeError: Cannot read property 'type' of undefined`.

A full backtrace example is 

```
failed Building production JavaScript and CSS bundles - 11.242s

 ERROR #98123  WEBPACK

Generating JavaScript bundles failed

Module build failed (from ./node_modules/postcss-loader/dist/cjs.js):
TypeError: Cannot read property 'type' of undefined
    at /Users/nobuhikosawai/.ghq/github.com/nobuhikosawai/blog/src/styles/global.css:31:1
    at Root.normalize (/Users/nobuhikosawai/.ghq/github.com/nobuhikosawai/blog/node_modules/postcss/lib/container.js:313:22)
    at Root.normalize (/Users/nobuhikosawai/.ghq/github.com/nobuhikosawai/blog/node_modules/postcss/lib/root.js:25:23)
    at Root.insertAfter (/Users/nobuhikosawai/.ghq/github.com/nobuhikosawai/blog/node_modules/postcss/lib/container.js:220:22)
    at Rule.after (/Users/nobuhikosawai/.ghq/github.com/nobuhikosawai/blog/node_modules/postcss/lib/node.js:148:17)
    at /Users/nobuhikosawai/.ghq/github.com/nobuhikosawai/blog/node_modules/postcss-dark-theme-class/index.js:50:18
    at /Users/nobuhikosawai/.ghq/github.com/nobuhikosawai/blog/node_modules/postcss/lib/container.js:379:44
    at AtRule.each (/Users/nobuhikosawai/.ghq/github.com/nobuhikosawai/blog/node_modules/postcss/lib/container.js:60:16)
    at Proxy.<anonymous> (/Users/nobuhikosawai/.ghq/github.com/nobuhikosawai/blog/node_modules/postcss/lib/container.js:376:30)
    at media (/Users/nobuhikosawai/.ghq/github.com/nobuhikosawai/blog/node_modules/postcss-dark-theme-class/index.js:38:18)
    at LazyResult.visitTick (/Users/nobuhikosawai/.ghq/github.com/nobuhikosawai/blog/node_modules/postcss/lib/lazy-result.js:456:16)
    at LazyResult.runAsync (/Users/nobuhikosawai/.ghq/github.com/nobuhikosawai/blog/node_modules/postcss/lib/lazy-result.js:372:30)
    at LazyResult.async (/Users/nobuhikosawai/.ghq/github.com/nobuhikosawai/blog/node_modules/postcss/lib/lazy-result.js:205:30)
    at LazyResult.then (/Users/nobuhikosawai/.ghq/github.com/nobuhikosawai/blog/node_modules/postcss/lib/lazy-result.js:190:17)
```