### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ themeSwitcher.addEventListener('change', () => {
 **Step 7:** Think of adding a small inline JS to prevent [FART] completely.
 
 ```html
-  <script defer>
+  <script>
     if (localStorage.theme === 'light') {
       html.classList.add('is-light')
     } else if (localStorage.theme === 'dark') {


### PR DESCRIPTION
`defer` makes no sense for the inline scripts. Please see:

https://html.spec.whatwg.org/multipage/scripting.html#htmlscriptelement:~:text=are%20affected%20by%20the%20async%20and%20defer%20attributes%2C%20but%20only%20when%20the%20src%20attribute%20is%20set

(And even if it worked, that rather would be harmful as the deferred scripts are executed out-of-sync with the first paint)