### PR TITLE
Add light-dark() support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ CSS solution for light/dark/auto theme switcher for websites.
   by subset/sunrise (all operating systems now have theme switching schedule).
 
 [PostCSS] plugin to make switcher to force dark or light theme by copying styles
-from media query to special class.
+from media query or [light-dark()](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/light-dark) color function to special class.
 
 [PostCSS]: https://github.com/postcss/postcss
 [FART]: https://css-tricks.com/flash-of-inaccurate-color-theme-fart/
@@ -27,6 +27,10 @@ from media query to special class.
   body {
     background: black
   }
+}
+
+section {
+  background: light-dark(white, black);
 }
 ```
 
@@ -47,24 +51,6 @@ html:where(.is-dark) {
 :where(html.is-dark) body {
   background: black
 }
-```
-
-By default (without classes on `html`), website will use browser dark/light
-theme. If user want to use dark theme, you set `html.is-dark` class.
-If user want to force light theme, you use `html.is-light`.
-
-This plugin also supports the [light-dark()](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/light-dark) color function:
-
-```css
-/* Input CSS */
-
-section {
-  background: light-dark(white, black);
-}
-```
-
-```css
-/* Output CSS */
 
 @media (prefers-color-scheme: dark) {
   :where(html:not(.is-light)) section {
@@ -74,7 +60,6 @@ section {
 :where(html.is-dark) section {
   background: black;
 }
-
 @media (prefers-color-scheme: light) {
   :where(html:not(.is-dark)) section {
     background: white;
@@ -84,6 +69,11 @@ section {
   background: white;
 }
 ```
+
+By default (without classes on `html`), website will use browser dark/light
+theme. If user want to use dark theme, you set `html.is-dark` class.
+If user want to force light theme, you use `html.is-light`.
+
 
 <a href="https://evilmartians.com/?utm_source=postcss-dark-theme-class">
   <img src="https://evilmartians.com/badges/sponsored-by-evil-martians.svg"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ CSS solution for light/dark/auto theme switcher for websites.
   by subset/sunrise (all operating systems now have theme switching schedule).
 
 [PostCSS] plugin to make switcher to force dark or light theme by copying styles
-from media query or [light-dark()](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/light-dark) color function to special class.
+from media query or [light-dark()](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/light-dark) to special class.
 
 [PostCSS]: https://github.com/postcss/postcss
 [FART]: https://css-tricks.com/flash-of-inaccurate-color-theme-fart/

--- a/README.md
+++ b/README.md
@@ -53,6 +53,38 @@ By default (without classes on `html`), website will use browser dark/light
 theme. If user want to use dark theme, you set `html.is-dark` class.
 If user want to force light theme, you use `html.is-light`.
 
+This plugin also supports the [light-dark()](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/light-dark) color function:
+
+```css
+/* Input CSS */
+
+section {
+  background: light-dark(white, black);
+}
+```
+
+```css
+/* Output CSS */
+
+@media (prefers-color-scheme: dark) {
+  :where(html:not(.is-light)) section {
+    background: black;
+  }
+}
+:where(html.is-dark) section {
+  background: black;
+}
+
+@media (prefers-color-scheme: light) {
+  :where(html:not(.is-dark)) section {
+    background: white;
+  }
+}
+:where(html.is-light) section {
+  background: white;
+}
+```
+
 <a href="https://evilmartians.com/?utm_source=postcss-dark-theme-class">
   <img src="https://evilmartians.com/badges/sponsored-by-evil-martians.svg"
        alt="Sponsored by Evil Martians" width="236" height="54">

--- a/README.md
+++ b/README.md
@@ -12,10 +12,11 @@ CSS solution for light/dark/auto theme switcher for websites.
   by subset/sunrise (all operating systems now have theme switching schedule).
 
 [PostCSS] plugin to make switcher to force dark or light theme by copying styles
-from media query or [light-dark()](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/light-dark) to special class.
+from media query or [light-dark()] to special class.
 
 [PostCSS]: https://github.com/postcss/postcss
 [FART]: https://css-tricks.com/flash-of-inaccurate-color-theme-fart/
+[light-dark()]: https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/light-dark
 
 ```css
 /* Input CSS */

--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ By default (without classes on `html`), website will use browser dark/light
 theme. If user want to use dark theme, you set `html.is-dark` class.
 If user want to force light theme, you use `html.is-light`.
 
-
 <a href="https://evilmartians.com/?utm_source=postcss-dark-theme-class">
   <img src="https://evilmartians.com/badges/sponsored-by-evil-martians.svg"
        alt="Sponsored by Evil Martians" width="236" height="54">

--- a/index.js
+++ b/index.js
@@ -84,12 +84,7 @@ module.exports = (opts = {}) => {
   return {
     AtRuleExit: {
       media: atrule => {
-        if (
-          !atrule.params.includes('dark') &&
-          !atrule.params.includes('light')
-        ) {
-          return
-        }
+        if (!atrule.params.includes('dark') && !atrule.params.includes('light')) return
 
         let params = atrule.params
         let fixedSelector = params.includes('dark') ? dark : light

--- a/index.test.js
+++ b/index.test.js
@@ -386,24 +386,37 @@ test('ignores already transformed rules - light scheme', () => {
 test('transforms light-dark()', () => {
   run(
     `html {
-  color: light-dark(white, black)
+  border: 1px solid light-dark(white, black)
 }`,
-    `@media (prefers-color-scheme: dark) {
+    `@media (prefers-color-scheme:dark) {
     html:where(:not(.is-light)) {
-        color: black
+        border: 1px solid black
     }
 }
 html:where(.is-dark) {
-    color: black
+    border: 1px solid black
 }
-@media (prefers-color-scheme: light) {
+@media (prefers-color-scheme:light) {
     html:where(:not(.is-dark)) {
-        color: white
+        border: 1px solid white
     }
 }
 html:where(.is-light) {
-    color: white
+    border: 1px solid white
 }`
+  )
+})
+
+test('does not transform light-dark() inside strings', () => {
+  run(
+    `html {
+  content: ' light-dark(white, black) \
+    light-dark(purple, yellow)
+  ';
+  background: url("light-dark(red, blue).png");
+  quotes: "light-dark(white, black)" "light-dark(red, green)";
+}`,
+    ``
   )
 })
 
@@ -412,7 +425,7 @@ test('transforms light-dark() and disables :where() of request', () => {
     `section {
   color: light-dark(#888, #eee)
 }`,
-    `@media (prefers-color-scheme: dark) {
+    `@media (prefers-color-scheme:dark) {
     html:not(.is-light) section {
         color: #eee
     }
@@ -420,7 +433,7 @@ test('transforms light-dark() and disables :where() of request', () => {
 html.is-dark section {
     color: #eee
 }
-@media (prefers-color-scheme: light) {
+@media (prefers-color-scheme:light) {
     html:not(.is-dark) section {
         color: #888
     }
@@ -437,13 +450,13 @@ test('processes inner at-rules with light-dark()', () => {
     `@media (min-width: 500px) {
       @media (print) {
         a {
-          background-color: light-dark(white, black)  
+          background-color: light-dark(white, black)
         }
       }
     }`,
     `@media (min-width: 500px) {
       @media (print) {
-        @media (prefers-color-scheme: dark) {
+        @media (prefers-color-scheme:dark) {
                   :where(html:not(.is-light)) a {
                         background-color: black
                   }
@@ -451,7 +464,7 @@ test('processes inner at-rules with light-dark()', () => {
         :where(html.is-dark) a {
                   background-color: black
             }
-        @media (prefers-color-scheme: light) {
+        @media (prefers-color-scheme:light) {
                   :where(html:not(.is-dark)) a {
                         background-color: white
                   }
@@ -466,23 +479,33 @@ test('processes inner at-rules with light-dark()', () => {
 
 test('ignores whitespaces for light-dark()', () => {
   run(
-    `a { color: light-dark( white ,  black  ) }
+    `a { background: radial-gradient(light-dark( red ,  yellow  ),
+light-dark( white ,  black  ),
+rgb(30 144 255)); }
 `,
-    `@media (prefers-color-scheme: dark) {
+    `@media (prefers-color-scheme:dark) {
     :where(html:not(.is-light)) a {
-        color: black
+        background: radial-gradient(yellow,
+black,
+rgb(30 144 255))
     }
 }
 :where(html.is-dark) a {
-    color: black
+    background: radial-gradient(yellow,
+black,
+rgb(30 144 255))
 }
-@media (prefers-color-scheme: light) {
+@media (prefers-color-scheme:light) {
     :where(html:not(.is-dark)) a {
-        color: white
+        background: radial-gradient(red,
+white,
+rgb(30 144 255))
     }
 }
 :where(html.is-light) a {
-    color: white
+    background: radial-gradient(red,
+white,
+rgb(30 144 255))
 }
 `
   )
@@ -493,23 +516,23 @@ test('changes root selectors for light-dark()', () => {
     `html, .s { --bg: light-dark(white, black) }
     p { color: light-dark(red, blue) }
 `,
-    `@media (prefers-color-scheme: dark) {
+    `@media (prefers-color-scheme:dark) {
     html:where(:not(.is-light)), .s:where(:not(.is-light)) {
-        --bg: black
+        --bg: black 
     }
 }
 html:where(.is-dark), .s:where(.is-dark) {
-    --bg: black
+    --bg: black 
 }
-@media (prefers-color-scheme: light) {
+@media (prefers-color-scheme:light) {
     html:where(:not(.is-dark)), .s:where(:not(.is-dark)) {
-        --bg: white
+        --bg: white 
     }
 }
 html:where(.is-light), .s:where(.is-light) {
-    --bg: white
+    --bg: white 
 }
-    @media (prefers-color-scheme: dark) {
+    @media (prefers-color-scheme:dark) {
     :where(html:not(.is-light)) p,:where(.s:not(.is-light)) p {
         color: blue
     }
@@ -517,7 +540,7 @@ html:where(.is-light), .s:where(.is-light) {
     :where(html.is-dark) p,:where(.s.is-dark) p {
     color: blue
 }
-    @media (prefers-color-scheme: light) {
+    @media (prefers-color-scheme:light) {
     :where(html:not(.is-dark)) p,:where(.s:not(.is-dark)) p {
         color: red
     }
@@ -535,23 +558,23 @@ test('changes root selector for light-dark()', () => {
     `body { --bg: light-dark(white, black) }
     p { color: light-dark(green, yellow) }
 `,
-    `@media (prefers-color-scheme: dark) {
+    `@media (prefers-color-scheme:dark) {
     body:where(:not(.is-light)) {
-        --bg: black
+        --bg: black 
     }
 }
 body:where(.is-dark) {
-    --bg: black
+    --bg: black 
 }
-@media (prefers-color-scheme: light) {
+@media (prefers-color-scheme:light) {
     body:where(:not(.is-dark)) {
-        --bg: white
+        --bg: white 
     }
 }
 body:where(.is-light) {
-    --bg: white
+    --bg: white 
 }
-    @media (prefers-color-scheme: dark) {
+    @media (prefers-color-scheme:dark) {
     :where(body:not(.is-light)) p {
         color: yellow
     }
@@ -559,7 +582,7 @@ body:where(.is-light) {
     :where(body.is-dark) p {
     color: yellow
 }
-    @media (prefers-color-scheme: light) {
+    @media (prefers-color-scheme:light) {
     :where(body:not(.is-dark)) p {
         color: green
     }

--- a/index.test.js
+++ b/index.test.js
@@ -416,7 +416,13 @@ test('does not transform light-dark() inside strings', () => {
   background: url("light-dark(red, blue).png");
   quotes: "light-dark(white, black)" "light-dark(red, green)";
 }`,
-    ``
+    `html {
+  content: ' light-dark(white, black) \
+    light-dark(purple, yellow)
+  ';
+  background: url("light-dark(red, blue).png");
+  quotes: "light-dark(white, black)" "light-dark(red, green)";
+}`
   )
 })
 

--- a/index.test.js
+++ b/index.test.js
@@ -314,18 +314,18 @@ test('allows to change class', () => {
 test('changes root selectors', () => {
   run(
     `@media (prefers-color-scheme: dark) {
-    html, .s { bg: black }
+    html, .s { --bg: black }
     p { color: white }
   }
-  html, .s { bg: white }
+  html, .s { --bg: white }
   p { color: black }`,
     `@media (prefers-color-scheme: dark) {
-    html:where(:not(.is-light)), .s:where(:not(.is-light)) { bg: black }
+    html:where(:not(.is-light)), .s:where(:not(.is-light)) { --bg: black }
     :where(html:not(.is-light)) p,:where(.s:not(.is-light)) p { color: white }
   }
-    html:where(.is-dark), .s:where(.is-dark) { bg: black }
+    html:where(.is-dark), .s:where(.is-dark) { --bg: black }
     :where(html.is-dark) p,:where(.s.is-dark) p { color: white }
-  html, .s { bg: white }
+  html, .s { --bg: white }
   p { color: black }`,
     { rootSelector: ['html', ':root', '.s'] }
   )
@@ -334,18 +334,18 @@ test('changes root selectors', () => {
 test('changes root selector', () => {
   run(
     `@media (prefers-color-scheme: dark) {
-    body { bg: black }
+    body { --bg: black }
     p { color: white }
   }
-  body { bg: white }
+  body { --bg: white }
   p { color: black }`,
     `@media (prefers-color-scheme: dark) {
-    body:where(:not(.is-light)) { bg: black }
+    body:where(:not(.is-light)) { --bg: black }
     :where(body:not(.is-light)) p { color: white }
   }
-    body:where(.is-dark) { bg: black }
+    body:where(.is-dark) { --bg: black }
     :where(body.is-dark) p { color: white }
-  body { bg: white }
+  body { --bg: white }
   p { color: black }`,
     { rootSelector: 'body' }
   )
@@ -354,32 +354,32 @@ test('changes root selector', () => {
 test('ignores already transformed rules - dark scheme', () => {
   run(
     `@media (prefers-color-scheme: dark) {
-    :root:not(.is-light) { bg: black }
+    :root:not(.is-light) { --bg: black }
     p { color: white }
   }
-  :root { bg: white }`,
+  :root { --bg: white }`,
     `@media (prefers-color-scheme: dark) {
-    :root:not(.is-light) { bg: black }
+    :root:not(.is-light) { --bg: black }
     :where(html:not(.is-light)) p { color: white }
   }
     :where(html.is-dark) p { color: white }
-  :root { bg: white }`
+  :root { --bg: white }`
   )
 })
 
 test('ignores already transformed rules - light scheme', () => {
   run(
     `@media (prefers-color-scheme: light) {
-    :root:not(.is-dark) { bg: black }
+    :root:not(.is-dark) { --bg: black }
     p { color: white }
   }
-  :root { bg: white }`,
+  :root { --bg: white }`,
     `@media (prefers-color-scheme: light) {
-    :root:not(.is-dark) { bg: black }
+    :root:not(.is-dark) { --bg: black }
     :where(html:not(.is-dark)) p { color: white }
   }
     :where(html.is-light) p { color: white }
-  :root { bg: white }`
+  :root { --bg: white }`
   )
 })
 
@@ -490,24 +490,24 @@ test('ignores whitespaces for light-dark()', () => {
 
 test('changes root selectors for light-dark()', () => {
   run(
-    `html, .s { bg: light-dark(white, black) }
+    `html, .s { --bg: light-dark(white, black) }
     p { color: light-dark(red, blue) }
 `,
     `@media (prefers-color-scheme: dark) {
     html:where(:not(.is-light)), .s:where(:not(.is-light)) {
-        bg: black
+        --bg: black
     }
 }
 html:where(.is-dark), .s:where(.is-dark) {
-    bg: black
+    --bg: black
 }
 @media (prefers-color-scheme: light) {
     html:where(:not(.is-dark)), .s:where(:not(.is-dark)) {
-        bg: white
+        --bg: white
     }
 }
 html:where(.is-light), .s:where(.is-light) {
-    bg: white
+    --bg: white
 }
     @media (prefers-color-scheme: dark) {
     :where(html:not(.is-light)) p,:where(.s:not(.is-light)) p {
@@ -532,24 +532,24 @@ html:where(.is-light), .s:where(.is-light) {
 
 test('changes root selector for light-dark()', () => {
   run(
-    `body { bg: light-dark(white, black) }
+    `body { --bg: light-dark(white, black) }
     p { color: light-dark(green, yellow) }
 `,
     `@media (prefers-color-scheme: dark) {
     body:where(:not(.is-light)) {
-        bg: black
+        --bg: black
     }
 }
 body:where(.is-dark) {
-    bg: black
+    --bg: black
 }
 @media (prefers-color-scheme: light) {
     body:where(:not(.is-dark)) {
-        bg: white
+        --bg: white
     }
 }
 body:where(.is-light) {
-    bg: white
+    --bg: white
 }
     @media (prefers-color-scheme: dark) {
     :where(body:not(.is-light)) p {


### PR DESCRIPTION
Closes #25 

If we try to convert code from this:
```css
a {
  color: light-dark(black, white);
}
```
To this:
```css
:where(html.is-light) a {
  color: black;
}
:where(html.is-dark) a {
  color: white;
}
```
Then it will not respect the user's preferred color scheme specified via system settings.
So we also need to use `prefers-color-scheme` media query.
This plugin already can transform `prefers-color-scheme`, so if we convert this:
```css
a {
  color: light-dark(black, white);
}
```
To this:
```css
@media (prefers-color-scheme: dark) {
  a {
    color: white;
  }
}

@media (prefers-color-scheme: light) {
  a {
    color: black;
  }
}
```
then the current plugin code will run and we will get the following:
```css
@media (prefers-color-scheme: dark) {
  :where(html:not(.is-light)) a {
    color: white;
  }
}
:where(html.is-dark) a {
  color: white;
}

@media (prefers-color-scheme: light) {
  :where(html:not(.is-dark)) a {
    color: black;
  }
}
:where(html.is-light) a {
  color: black;
}
```
